### PR TITLE
docs: Improve documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,18 +13,6 @@ They are grouped by type (fix, feat, etc) and a release is created using the
 GitHub API. The release content is set as action output, so it can be used in
 subsequent steps.
 
-## Pre-requisites
-
-You need to have setup node and npx in your workflow before using this action.
-
-```yaml
-steps:
-  - name: Setup node
-    uses: actions/setup-node@v2
-    with:
-      node-version: '20'
-```
-
 ## Inputs
 
 | Name           | Description                          | Required | Default |
@@ -43,10 +31,28 @@ steps:
 | `release-body`  | Release description   |
 | `release-url`   | Release URL to GitHub |
 
-## Example usage
+
+## Pre-requisites
+
+You need to have setup node and npx in your workflow before using this action.
 
 ```yaml
-on: [deployment]
+steps:
+  - name: Setup node
+    uses: actions/setup-node@v2
+    with:
+      node-version: '20'
+```
+
+
+## Example usage
+
+See a simple example below that illustrates how to use this action.
+For more advanced examples, see the [example-workflows](./example-workflows) directory.
+
+```yaml
+on:
+  - deployment_status
 # Release job:
 jobs:
   deploy:
@@ -54,6 +60,7 @@ jobs:
     name: Deploy
     permissions:
       contents: write
+    if: ${{ startsWith(github.event.deployment.environment, 'production-') && github.event.deployment_status.state == 'success' }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v4

--- a/README.md
+++ b/README.md
@@ -31,20 +31,6 @@ subsequent steps.
 | `release-body`  | Release description   |
 | `release-url`   | Release URL to GitHub |
 
-
-## Pre-requisites
-
-You need to have setup node and npx in your workflow before using this action.
-
-```yaml
-steps:
-  - name: Setup node
-    uses: actions/setup-node@v2
-    with:
-      node-version: '20'
-```
-
-
 ## Example usage
 
 See a simple example below that illustrates how to use this action.

--- a/example-workflows/get-sha-from-previous-deployment.yml
+++ b/example-workflows/get-sha-from-previous-deployment.yml
@@ -1,0 +1,53 @@
+on:
+  - deployment_status
+# Release job:
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    name: Deploy
+    permissions:
+      contents: write
+    if: ${{ startsWith(github.event.deployment.environment, 'production-') && github.event.deployment_status.state == 'success' }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Find name of workspace from environment
+        id: get-workspace
+        run: |
+          workspace=$(echo ${{ github.event.deployment.environment }} | cut -d '-' -f 2-)
+          echo "workspace=$workspace" >> "$GITHUB_OUTPUT"
+
+      - uses: octokit/request-action@v2.x
+        id: get-previous-deployment
+        with:
+          route: GET /repos/{owner}/{repo}/deployments
+          # Query parameters are reported as invalid, but they do work in octokit/request-action
+          # Validating wildcard inputs is currently not supported by github actions, but they work
+          environment: ${{ github.event.deployment.environment }}
+          per_page: 1
+          page: 2
+          owner: ${{ github.repository_owner }}
+          repo: <your-repo> # No context for this, so you need to hardcode it
+        env:
+            GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Create release
+        uses: go-fjords/turbo-monorepo-release-action@main
+        id: create-release
+        with:
+          # We need the token with write permissions to do git operations and create the release
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          # The name of the turbo/pnpm workspace to check for changes
+          workspace: ${{ steps.get-workspace.outputs.workspace }}
+          # The prefix is used to create the release title
+          prefix: ${{ github.event.deployment.environment }}
+          # Get the start commit for the release (exclusive, not part of the release)
+          from: ${{ steps.get-previous-deployment.outputs.data[0].sha }}
+          # Get the final commit for the release (inclusive, part of the release)
+          to: ${{ github.event.deployment.ref }}
+
+      - name: Print release URL
+        run: echo ${{ steps.create-release.outputs.release-url }}


### PR DESCRIPTION
Change the example workflow use the deployment_status event instead of the deployment event. Usually you only want to run the create release action when a deployment has been successful.

Add a directory of example workflows to show users more complete and advanced examples. Currently only one example showing how to get the sha from the previous deployment using the octokit action to query the github API.