### PR TITLE
chore: Update LICENSE and CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,4 +1,4 @@
 # Repository CODEOWNERS
 
-* @actions/actions-runtime
-* @ncalteen
+* @go-fjords/maintainers
+* @snorremd

--- a/LICENSE
+++ b/LICENSE
@@ -1,7 +1,7 @@
 
 The MIT License (MIT)
 
-Copyright (c) 2018 GitHub, Inc. and contributors
+Copyright (c) 2023 Adventure Tech AS and contributors
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
All action code is now written by Adventure Tech AS so it is more correct to license under our company's copyright. Retain the MIT license as the action should be usable by all.

Updated codeowners file to gofjords maintainers and me.