### PR TITLE
fix: Try removing unneeded quotes in turbo cmd

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -52476,7 +52476,7 @@ async function processCommits(commits, workspace) {
             'turbo',
             'run',
             'build',
-            `--filter='${workspace}...[${commit.sha}^1]'`,
+            '--filter=${workspace}...[${commit.sha}^1]',
             '--dry=json'
         ], {
             listeners: {

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -163,7 +163,7 @@ export async function processCommits(
         'turbo',
         'run',
         'build',
-        `--filter='${workspace}...[${commit.sha}^1]'`,
+        '--filter=${workspace}...[${commit.sha}^1]',
         '--dry=json'
       ],
       {


### PR DESCRIPTION
Turbo command when run in GitHub Actions never return a relevant commit. Might be because turbo filter argument is quoted.